### PR TITLE
Correct ordinal names of bits

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,9 @@
 			<p>If you look at the ASCII table below then there are some interesting properties: in
 			the 1<sup>st</sup> column you can see how the left two bits are always set to zero, and
 			that the other 5 bits count to 31 (32 characters in total; it starts at 0). The
-			2<sup>nd</sup> column repeats this pattern but with the 5th bit set to 1 (remember, read
-			binary numbers from right-to-left, so that’s 5<sup>th</sup> from the right). The
-			3<sup>rd</sup> column repeats this pattern again with the 6<sup>th</sup> bit set, and
+			2<sup>nd</sup> column repeats this pattern but with the 6th bit set to 1 (remember, read
+			binary numbers from right-to-left, so that’s 6<sup>th</sup> counting from the right). The
+			3<sup>rd</sup> column repeats this pattern again with the 7<sup>th</sup> bit set, and
 			the final column has both bits set.</p>
 
 			<p>The interesting part here is that the letters A-Z and some punctuation map directly


### PR DESCRIPTION
Later paragraphs use the (correct) names "6th" and "7th" bit when
talking about clearing bits. Bring an early paragraph in line with that
to avoid confusion.

One could conceivably prefer counting from 0, such that the earlier paragraphs
are correct and the later ones need correcting, but I believe this is slightly
more intuitive.